### PR TITLE
Adjust database connection timeout

### DIFF
--- a/FloofGangStuff/settings.py
+++ b/FloofGangStuff/settings.py
@@ -99,7 +99,7 @@ DATABASES = {
         "NAME": config("DB_DATABASE"),
         "USER": config("DB_USERNAME"),
         "PASSWORD": config("DB_PASSWORD"),
-        "CONN_MAX_AGE": 120
+        "CONN_MAX_AGE": 28800
     }
 }
 


### PR DESCRIPTION
MariaDB default (or at least the default with my setup, is 28800 seconds, not 120